### PR TITLE
Fix typo and add instruction to use gcc-6.3 on Linux

### DIFF
--- a/Model_Generation.m
+++ b/Model_Generation.m
@@ -157,6 +157,8 @@ adjN_fun = Function('adjN_fun',{states,params,refN, QN, mu_x,muN_g},{dobjN, adj_
 
 generate=input('Would you like to generate the source code?(y/n)','s');
 
+gcc_version==input('Would you like to compile the 6.3 release of gcc?(y/n)','s');
+
 if strcmp(generate,'y')
 
     disp('                           ');
@@ -235,7 +237,11 @@ if strcmp(compile,'y')
        CC_FLAGS='CXXFLAGS="$CXXFLAGS -Wall"'; % use MinGW not VS studio
     end
     if OS_LINUX 
-       CC_FLAGS = 'GCC="/usr/bin/gcc"';
+       	if strcmp(gcc_version, 'y')
+	    CC_FLAGS = 'GCC="/usr/bin/gcc-6.3"';
+	else
+	    CC_FLAGS = 'GCC="/usr/bin/gcc"';
+	end
     end
     if OS_MAC
        CC_FLAGS = '';

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Please install Matlab supported MinGW compiler at https://www.mathworks.com/matl
 
 Install gcc by running "sudo apt-get install gcc"
 
+**Note:** MATLAB is incompatible with the latest releases of gcc, even using the 2019b or 2020a releases of MATLAB (the latest versions of MATLAB at the time of this work). MATLAB needs this compiler to generate the mex64 files it needs to with the MATMPC toolbox. A workaround for this problem is [described at this link](https://www.mathworks.com/matlabcentral/answers/407502-incompatible-gcc-version-with-mex) and below.
+
+1. Download the 6.3.x release of gcc from [this link](https://drive.google.com/file/d/1VYb08z7BQH6LQDimcob_jsDHFjjNO8dY/view?usp=sharing)
+2. Move to the folder where the file is contained and run this command from the terminal line `sudo dpkg -i gcc-6-3-0_6.3.0_amd64.deb`
+3. Answer yes when asked to change the compiler to gcc-6.3 in MATLAB
+
 ### MacOS:
 
 Install Xcode from app store

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please install Matlab supported MinGW compiler at https://www.mathworks.com/matl
 
 ### Linux:
 
-Install gcc by running "sudo install apt-get gcc"
+Install gcc by running "sudo apt-get install gcc"
 
 ### MacOS:
 

--- a/mex_core/Compile_Mex.m
+++ b/mex_core/Compile_Mex.m
@@ -27,7 +27,11 @@ if OS_WIN
    CC_FLAGS='CXXFLAGS="$CXXFLAGS -Wall"'; % use MinGW not VS studio
 end
 if OS_LINUX 
-   CC_FLAGS = 'GCC="/usr/bin/gcc"';
+    if strcmp(gcc_version, 'y')
+	CC_FLAGS = 'GCC="/usr/bin/gcc-6.3"';
+    else
+	CC_FLAGS = 'GCC="/usr/bin/gcc"';
+    end
 end
 if OS_MAC
    CC_FLAGS = '';


### PR DESCRIPTION
Fix typo in the README.md file